### PR TITLE
修复测试类从org.smali:dexlib2迁移到com.android.tools.smali:smali-dexlib2导致的编译失败

### DIFF
--- a/nmm-protect/apkprotect/build.gradle
+++ b/nmm-protect/apkprotect/build.gradle
@@ -45,8 +45,8 @@ compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_9
-    targetCompatibility = JavaVersion.VERSION_1_9
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/nmm-protect/apkprotect/src/test/java/com/nmmedit/apkprotect/dex2c/filters/SimpleRulesTest.java
+++ b/nmm-protect/apkprotect/src/test/java/com/nmmedit/apkprotect/dex2c/filters/SimpleRulesTest.java
@@ -1,10 +1,10 @@
 package com.nmmedit.apkprotect.dex2c.filters;
 
 import junit.framework.TestCase;
-import org.jf.dexlib2.Opcodes;
-import org.jf.dexlib2.dexbacked.DexBackedClassDef;
-import org.jf.dexlib2.dexbacked.DexBackedDexFile;
-import org.jf.dexlib2.dexbacked.DexBackedMethod;
+import com.android.tools.smali.dexlib2.Opcodes;
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedClassDef;
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile;
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedMethod;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;

--- a/nmm-protect/apkprotect/src/test/java/com/nmmedit/dex2c/ClassMethodToNative.java
+++ b/nmm-protect/apkprotect/src/test/java/com/nmmedit/dex2c/ClassMethodToNative.java
@@ -2,11 +2,11 @@ package com.nmmedit.dex2c;
 
 
 import com.nmmedit.apkprotect.dex2c.filters.ClassAndMethodFilter;
-import org.jf.dexlib2.AccessFlags;
-import org.jf.dexlib2.HiddenApiRestriction;
-import org.jf.dexlib2.base.reference.BaseTypeReference;
-import org.jf.dexlib2.iface.*;
-import org.jf.dexlib2.iface.reference.MethodReference;
+import com.android.tools.smali.dexlib2.AccessFlags;
+import com.android.tools.smali.dexlib2.HiddenApiRestriction;
+import com.android.tools.smali.dexlib2.base.reference.BaseTypeReference;
+import com.android.tools.smali.dexlib2.iface.*;
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/nmm-protect/apkprotect/src/test/java/com/nmmedit/dex2c/ClassToSymDex.java
+++ b/nmm-protect/apkprotect/src/test/java/com/nmmedit/dex2c/ClassToSymDex.java
@@ -1,11 +1,11 @@
 package com.nmmedit.dex2c;
 
 import com.nmmedit.apkprotect.dex2c.filters.ClassAndMethodFilter;
-import org.jf.dexlib2.base.reference.BaseTypeReference;
-import org.jf.dexlib2.iface.Annotation;
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.iface.Field;
-import org.jf.dexlib2.iface.Method;
+import com.android.tools.smali.dexlib2.base.reference.BaseTypeReference;
+import com.android.tools.smali.dexlib2.iface.Annotation;
+import com.android.tools.smali.dexlib2.iface.ClassDef;
+import com.android.tools.smali.dexlib2.iface.Field;
+import com.android.tools.smali.dexlib2.iface.Method;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/nmm-protect/apkprotect/src/test/java/com/nmmedit/dex2c/Dex2cTest.java
+++ b/nmm-protect/apkprotect/src/test/java/com/nmmedit/dex2c/Dex2cTest.java
@@ -7,12 +7,12 @@ import com.nmmedit.apkprotect.dex2c.converter.instructionrewriter.InstructionRew
 import com.nmmedit.apkprotect.dex2c.converter.instructionrewriter.NoneInstructionRewriter;
 import com.nmmedit.apkprotect.dex2c.converter.testbuild.ClassMethodImplCollection;
 import com.nmmedit.apkprotect.dex2c.filters.ClassAndMethodFilter;
-import org.jf.dexlib2.AccessFlags;
-import org.jf.dexlib2.Opcodes;
-import org.jf.dexlib2.dexbacked.DexBackedDexFile;
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.iface.Method;
-import org.jf.dexlib2.writer.pool.DexPool;
+import com.android.tools.smali.dexlib2.AccessFlags;
+import com.android.tools.smali.dexlib2.Opcodes;
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile;
+import com.android.tools.smali.dexlib2.iface.ClassDef;
+import com.android.tools.smali.dexlib2.iface.Method;
+import com.android.tools.smali.dexlib2.writer.pool.DexPool;
 import org.junit.Test;
 
 import java.io.BufferedInputStream;


### PR DESCRIPTION
修复测试类从org.smali:dexlib2迁移到com.android.tools.smali:smali-dexlib2导致的编译失败